### PR TITLE
ignore vendor directory when working on Google Cloud Shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 _site/*
 _drafts/*
 .idea
+vendor/*


### PR DESCRIPTION
When developing on Google Cloud Shell (and other places) we have to install gems to ./vendor/

This PR ignores that directory so that the installed dependencies don't get committed to git.